### PR TITLE
Add preserveRoot and rootName optional elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Simple Maven plugin for generating ZIP files.
   <configuration>
     <inputDirectory>${project.basedir}/src/main/java</inputDirectory>
     <outputDirectory>C:/mydir</outputDirectory>
+    <preserveRoot>true</preserveRoot>
     <zipName>my-zip-name</zipName>
   </configuration>
 </plugin>
@@ -38,6 +39,8 @@ Simple Maven plugin for generating ZIP files.
 
 - **inputDirectory**: `${project.build.outputDirectory}` (your project target/classes directory)
 - **outputDirectory**: `${project.build.directory}` (your project target directory)
+- **preserveRoot**: `false` (if true, will use the input directory name as the root of the zip, if false will use [project-name]-[project-version])
+- **rootName**: `${project.build.finalName}` (the name to use as the root of the zip, if provided it will cause `preserveRoot` element to be ignored)
 - **zipName**: `${project.build.finalName}` ([project-name]-[project-version])
 
 <sub>Copyright (c) 2019 Donato Rimenti</sub>

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Simple Maven plugin for generating ZIP files.
     <inputDirectory>${project.basedir}/src/main/java</inputDirectory>
     <outputDirectory>C:/mydir</outputDirectory>
     <preserveRoot>true</preserveRoot>
+    <rootName>my-root-name</rootName>
     <zipName>my-zip-name</zipName>
   </configuration>
 </plugin>

--- a/src/main/java/co/aurasphere/maven/plugins/zip/ZipMojo.java
+++ b/src/main/java/co/aurasphere/maven/plugins/zip/ZipMojo.java
@@ -32,6 +32,7 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+import org.zeroturnaround.zip.NameMapper;
 import org.zeroturnaround.zip.ZipUtil;
 
 /**
@@ -71,6 +72,12 @@ public class ZipMojo extends AbstractMojo {
 	@Parameter(defaultValue = "${project.build.finalName}", property = "zipName")
 	private String zipName;
 
+    @Parameter(property = "preserveRoot")
+    private boolean preserveRoot;
+
+    @Parameter(property = "rootName")
+    private String rootName;
+
 	/*
 	 * (non-Javadoc)
 	 * 
@@ -99,7 +106,16 @@ public class ZipMojo extends AbstractMojo {
 
 		// Builds the actual zip file.
 		File artifact = new File(outputDirectory, zipName + ".zip");
-		ZipUtil.pack(inputDirectory, artifact);
+
+        if (rootName == null || rootName.isBlank()) {
+		    ZipUtil.pack(inputDirectory, artifact, preserveRoot);
+        } else {
+		    ZipUtil.pack(inputDirectory, artifact, new NameMapper() {
+                public String map(String name) {
+                    return rootName + "/" + name;
+                }
+            });
+        }
 
 		// Sets the artifact file inside the project.
 		project.getArtifact().setFile(artifact);

--- a/src/test/java/co/aurasphere/maven/plugins/zip/ZipMojoTest.java
+++ b/src/test/java/co/aurasphere/maven/plugins/zip/ZipMojoTest.java
@@ -37,6 +37,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.internal.util.reflection.Whitebox;
 import org.zeroturnaround.zip.ZipException;
+import org.zeroturnaround.zip.ZipUtil;
 
 /**
  * Tests for {@link ZipMojo}.
@@ -139,5 +140,79 @@ public class ZipMojoTest {
 		// Checks that the zip has been succesfully created.
 		Assert.assertNotNull(artifact.getFile());
 	}
+
+    /**
+     * Tests {@link ZipMojo#execute()} by building a zip file without errors.
+     *
+     * @throws MojoExecutionException if an error occurs during the plugin execution
+     * @throws IOException            if an error occurs while creating temporary
+     *                                directories
+     */
+    @Test
+    public void testZipPreserveRootOk() throws MojoExecutionException, IOException {
+        // Creates a temporary file to zip. This is an assumption to the test.
+        File rootFolder = tempFolder.newFolder();
+        File inputFolder = new File(rootFolder, "inputFolder");
+        Assume.assumeTrue(inputFolder.mkdir());
+        File zipFile = new File(inputFolder, "zipFile");
+        Assume.assumeTrue(zipFile.createNewFile());
+
+        // Mocks the internal state.
+        MavenProject project = new MavenProject();
+        Artifact artifact = new ProjectArtifact(project);
+        project.setArtifact(artifact);
+        Whitebox.setInternalState(zipMojo, "inputDirectory", inputFolder);
+        Whitebox.setInternalState(zipMojo, "outputDirectory", tempFolder.getRoot());
+        Whitebox.setInternalState(zipMojo, "preserveRoot", true);
+        Whitebox.setInternalState(zipMojo, "project", project);
+
+        // Executes the plugin.
+        zipMojo.execute();
+
+        Assume.assumeTrue(zipFile.delete());
+        Assume.assumeTrue(inputFolder.delete());
+
+        // Checks that the zip has been successfully created.
+        Assert.assertNotNull(artifact.getFile());
+        ZipUtil.unpack(artifact.getFile(), rootFolder);
+        Assert.assertTrue(new File(rootFolder, "inputFolder").exists());
+    }
+
+    /**
+     * Tests {@link ZipMojo#execute()} by building a zip file without errors.
+     *
+     * @throws MojoExecutionException if an error occurs during the plugin execution
+     * @throws IOException            if an error occurs while creating temporary
+     *                                directories
+     */
+    @Test
+    public void testZipSetRootNameOk() throws MojoExecutionException, IOException {
+        // Creates a temporary file to zip. This is an assumption to the test.
+        File rootFolder = tempFolder.newFolder();
+        File inputFolder = new File(rootFolder, "inputFolder");
+        Assume.assumeTrue(inputFolder.mkdir());
+        File zipFile = new File(inputFolder, "zipFile");
+        Assume.assumeTrue(zipFile.createNewFile());
+
+        // Mocks the internal state.
+        MavenProject project = new MavenProject();
+        Artifact artifact = new ProjectArtifact(project);
+        project.setArtifact(artifact);
+        Whitebox.setInternalState(zipMojo, "inputDirectory", inputFolder);
+        Whitebox.setInternalState(zipMojo, "outputDirectory", tempFolder.getRoot());
+        Whitebox.setInternalState(zipMojo, "rootName", "alternativeRootName");
+        Whitebox.setInternalState(zipMojo, "project", project);
+
+        // Executes the plugin.
+        zipMojo.execute();
+
+        Assume.assumeTrue(zipFile.delete());
+        Assume.assumeTrue(inputFolder.delete());
+
+        // Checks that the zip has been successfully created.
+        Assert.assertNotNull(artifact.getFile());
+        ZipUtil.unpack(artifact.getFile(), rootFolder);
+        Assert.assertTrue(new File(rootFolder, "alternativeRootName").exists());
+    }
 
 }

--- a/src/test/java/co/aurasphere/maven/plugins/zip/ZipMojoTest.java
+++ b/src/test/java/co/aurasphere/maven/plugins/zip/ZipMojoTest.java
@@ -215,4 +215,42 @@ public class ZipMojoTest {
         Assert.assertTrue(new File(rootFolder, "alternativeRootName").exists());
     }
 
+    /**
+     * Tests {@link ZipMojo#execute()} by building a zip file without errors.
+     *
+     * @throws MojoExecutionException if an error occurs during the plugin execution
+     * @throws IOException            if an error occurs while creating temporary
+     *                                directories
+     */
+    @Test
+    public void testZipSetRootNameOverridesPreserveRootOk() throws MojoExecutionException, IOException {
+        // Creates a temporary file to zip. This is an assumption to the test.
+        File rootFolder = tempFolder.newFolder();
+        File inputFolder = new File(rootFolder, "inputFolder");
+        Assume.assumeTrue(inputFolder.mkdir());
+        File zipFile = new File(inputFolder, "zipFile");
+        Assume.assumeTrue(zipFile.createNewFile());
+
+        // Mocks the internal state.
+        MavenProject project = new MavenProject();
+        Artifact artifact = new ProjectArtifact(project);
+        project.setArtifact(artifact);
+        Whitebox.setInternalState(zipMojo, "inputDirectory", inputFolder);
+        Whitebox.setInternalState(zipMojo, "outputDirectory", tempFolder.getRoot());
+        Whitebox.setInternalState(zipMojo, "preserveRoot", true);
+        Whitebox.setInternalState(zipMojo, "rootName", "alternativeRootName");
+        Whitebox.setInternalState(zipMojo, "project", project);
+
+        // Executes the plugin.
+        zipMojo.execute();
+
+        Assume.assumeTrue(zipFile.delete());
+        Assume.assumeTrue(inputFolder.delete());
+
+        // Checks that the zip has been successfully created.
+        Assert.assertNotNull(artifact.getFile());
+        ZipUtil.unpack(artifact.getFile(), rootFolder);
+        Assert.assertTrue(new File(rootFolder, "alternativeRootName").exists());
+    }
+
 }


### PR DESCRIPTION
I went to use your plugin today as it's much easier to use than the maven assembly plugin for want I want to do, however, I had to modify it to fit my exact requirements and I was hoping you would accept this PR into the plugin. The added functionality allows either setting a specific root name for the zip file contents, or the ability to preserve the name from the root input folder.

Being able to specify the archive root name independently of the resulting artifacts file name is useful as it allows the zip file name to carry version information from the POM, while the extracted archive will have the 'correct' root name without having to use a rename option when running a zip extract command.